### PR TITLE
Fix: buildDirTree should deal with files getting deleted quickly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `System.Directory.Contents.Zipper` for convenient navigation and modification of directory contents
 * Add more examples to readme
 * Breaking change: `DirTree_Dir` and `Symlink_External` child nodes are now stored as a `Map`
+* Fix: buildDirTree fails as a file gets deleted quickly.
 
 ## 0.1.0.0
 


### PR DESCRIPTION
To reproduce:

    touch test.md; sleep 0.1; rm test.md

Run this ^ whilst `buildDirTree` is being evaluated. An exception from `pathIsSymbolicLink` will be thrown due to missing file. This function should only be called on existing file, explaining this change, which fixes the bug.

Fixes https://github.com/srid/neuron/issues/513